### PR TITLE
Ajouter des exceptions au système de mute

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -48,7 +48,7 @@ impl Bot {
             container.add_component(cmp::SlashCommand::new(app_id, ref_container.clone(), owners_id));
             container.add_component(cmp::Misc::new(app_id, perms, ref_container.clone()));
             container.add_component(cmp::DalleMini);
-            container.add_component(cmp::Autobahn::new(modo));
+            container.add_component(cmp::Autobahn::new(modo, config.autobahn.unwrap_or_default()));
         }
         let client = Client::builder(&config_bot.token, GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT)
             .raw_event_handler(ref_container.read().await.get_event_dispatcher())

--- a/src/components/autobahn/mod.rs
+++ b/src/components/autobahn/mod.rs
@@ -41,7 +41,7 @@ impl Autobahn {
             Some(member) => member.roles.iter().map(|r| config::Mentionable::Role(r.0)).collect::<Vec<_>>(),
             None => return,
         };
-        if self.config.has(&roles) {
+        if self.config.has_exception(&roles) {
             return;
         }
         log_info!("MessageCreateEvent");

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub struct Autobahn {
 }
 
 impl Autobahn {
-    pub fn has(&self, mention: &[Mentionable]) -> bool {
+    pub fn has_exception(&self, mention: &[Mentionable]) -> bool {
         self.exceptions.iter().any(|e| mention.contains(e))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,7 @@ pub struct Autobahn {
 
 impl Autobahn {
     pub fn has(&self, mention: &[Mentionable]) -> bool {
-        mention.iter().any(|e| self.exceptions.contains(e))
+        self.exceptions.iter().any(|e| mention.contains(e))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,12 +17,31 @@ use serde::Deserialize;
 pub struct Config {
     pub bot: Bot,
     pub tickets: Option<Tickets>,
+    pub autobahn: Option<Autobahn>,
     #[serde(skip)]
     filepath: PathBuf,
 }
 #[derive(Deserialize)]
 pub struct Tickets {
     pub default_category: Option<String>
+}
+
+#[derive(Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "id")]
+pub enum Mentionable {
+    User(u64),
+    Role(u64),
+}
+
+#[derive(Deserialize, Default)]
+pub struct Autobahn {
+    exceptions: Vec<Mentionable>,
+}
+
+impl Autobahn {
+    pub fn has(&self, mention: &[Mentionable]) -> bool {
+        mention.iter().any(|e| self.exceptions.contains(e))
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Désactiver le système de mute (autobahn) sur certaines exceptions configurées dans le fichier de config